### PR TITLE
Setting up a DESC package with setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,26 @@ model lenses as mixtures of Gaussians. Our goals are to
 
 
 ## Set-up and testing
-For now, this is done using the DM stack-style setup from the `desc_package_template`: from `bash`
+
+To use (and not develop) `SLRealizer`, you can pip install it with
 ```
-$ source <SLRealizer install directory>/setup/setup.sh
-$ nosetests <SLRealizer install directory>
+pip install git+git://github.com/LSSTDESC/SLRealizer.git#egg=slrealizer
 ```
-We'd like to switch to `setup.py` soon, as this is likely to be a pure python, stack-free analysis project.
+
+To help develop it, fork and clone the repo, `cd` there, and then install the package with
+```
+python setup.py develop
+```
+To run the tests, do
+```
+nosetests <SLRealizer install directory>
+```
+
 
 ## Demo
 
 Watch this space!
+
 
 ## People
 * [Phil Marshall](https://github.com/LSSTDESC/SLRealizer/issues/new?body=@drphilmarshall) (SLAC)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,64 @@
+from setuptools import setup
+
+setup(# package information
+      name="slrealizer",
+      version="0.0",
+      author="Phil Marshall",
+      author_email="dr.phil.marshall@gmail.com",
+      description="Catalog-level realization of simulated gravitational lenses",
+      long_description=open("README.md").read(),
+      url="https://github.com/LSSTDESC/SLRealizer",
+      packages=['desc.slrealizer'],
+      package_dir={'desc.slrealizer':'python/desc'},
+      include_package_data=True,
+      package_data={'slrealizer': ['data/*']},
+      classifiers=[
+          "Development Status :: 4 - Beta",
+          "License :: OSI Approved :: BSD License",
+          "Intended Audience :: Developers",
+          "Intended Audience :: Science/Research",
+          "Operating System :: OS Independent",
+          "Programming Language :: Python",
+      ],
+      install_requires=["numpy", "scipy", "matplotlib", "astropy", "om10"],
+)
+
+# The above code does not work. `python setup.py develop` completes with
+# no complaints, but the package does not import. Here's the log:
+
+# $ python setup.py develop
+# running develop
+# running egg_info
+# writing requirements to slrealizer.egg-info/requires.txt
+# writing slrealizer.egg-info/PKG-INFO
+# writing top-level names to slrealizer.egg-info/top_level.txt
+# writing dependency_links to slrealizer.egg-info/dependency_links.txt
+# writing manifest file 'slrealizer.egg-info/SOURCES.txt'
+# running build_ext
+# Creating /Users/pjm/miniconda2/envs/lsst/lib/python2.7/site-packages/slrealizer.egg-link (link to .)
+# Adding slrealizer 0.0 to easy-install.pth file
+# ...
+# Using /Users/pjm/miniconda2/envs/lsst/lib/python2.7/site-packages
+# Finished processing dependencies for slrealizer==0.0
+#
+# $ python
+# Python 2.7.12 |Continuum Analytics, Inc.| (default, Jul  2 2016, 17:43:17)
+# [GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)] on darwin
+# Type "help", "copyright", "credits" or "license" for more information.
+# Anaconda is brought to you by Continuum Analytics.
+# Please check out: http://continuum.io/thanks and https://anaconda.org
+# >>> import desc.slrealizer
+# Traceback (most recent call last):
+#   File "<stdin>", line 1, in <module>
+# ImportError: No module named slrealizer
+# >>> import slrealizer
+# Traceback (most recent call last):
+#   File "<stdin>", line 1, in <module>
+# ImportError: No module named slrealizer
+# >>> import desc
+# >>> dir(desc)
+# ['__builtins__', '__doc__', '__file__', '__name__', '__package__', '__path__', 'pkgutil']
+# >>> desc.__package__
+# 'desc'
+
+# So 'desc' is setup as a package, but desc.slrealizer is not.


### PR DESCRIPTION
Hi @jchiang87 - this is a new package, started using the cookiecutter, but it's a pure python, stack-free project, such that it could be pip installed and python setup. I particularly like the way 
```
python setup.py develop
```
takes care of the paths etc, in principle, and does not have to be run anew every time. So, I'm trying to make this work in this repo, and am having trouble navigating the `desc.slrealizer` namespace. I'd prefer not to mess with the structure we have, but at the moment `import desc.slrealizer` is failing. Can you see what I'm doing wrong in `setup.py`? Thanks!
